### PR TITLE
Misc. Fixes

### DIFF
--- a/bpf-files.md
+++ b/bpf-files.md
@@ -21,7 +21,7 @@ Note: Although specifying "-fno-omit-frame-pointer" is edundant when optimizatio
 
 #### Task 2: Collect I/O Latency Information
 
-For the sake of simplicity, assume you were already told that the `logger` application exhibits occasionally latency. You suspect that this is a result of slow I/O operations. Run the following command to get a distribution of block I/O operation latency across the system:
+For the sake of simplicity, assume you were already told that the `logger` application occasionally exhibits latency. You suspect that this is a result of slow I/O operations. Run the following command to get a distribution of block I/O operation latency across the system:
 
 ```
 # biolatency 1

--- a/bpf-files.md
+++ b/bpf-files.md
@@ -15,6 +15,8 @@ $ gcc -g -fno-omit-frame-pointer -O0 -lpthread logger.c -o logger   # on FC
 
 Next, run `./logger` -- it sits quietly in the background and churns some log files.
 
+Note: Although specifying "-fno-omit-frame-pointer" is edundant when optimizations are turned off, it's a good habit to compile with "-fno-omit-frame-pointer" whenever you're going to use tracing tools.
+
 - - -
 
 #### Task 2: Collect I/O Latency Information

--- a/bpf-files.md
+++ b/bpf-files.md
@@ -35,6 +35,9 @@ The result is likely a bimodal distribution. A lot of the operations complete ve
 
 You should be able to quickly see that there are some fairly large I/Os performed by the `logger` application that take longer than other smaller I/Os.
 
+Note: If you use an encrypted filesystem, you may see the I/Os requests as occuring on behalf
+of dmcrypt. This is a current limitation of `biosnoop`.
+
 - - -
 
 #### Task 3: Observe Slow File I/O Operations

--- a/bpf-issues.md
+++ b/bpf-issues.md
@@ -38,10 +38,6 @@ The tool contribution guidelines require running pep8 and fixing style issues. T
 
 Essentially, once stack tracing was introduced in `trace`, there's no longer need for `stacksnoop`. To retain compatibility and discoverability, we can turn `stacksnoop` into a wrapper that invokes `trace` with the appropriate flags.
 
-* [uprobe/tracepoint/USDT support in `funccount`](https://github.com/iovisor/bcc/issues/731) *Medium*
-
-This can be very useful for quickly discovering the rate of things happening in the system. Most of the code should be salvageable from `stackcount`'s recent update.
-
 * [More options in `opensnoop`](https://github.com/iovisor/bcc/issues/616) *Medium*
 
 Bring `opensnoop` up to par with an older version that uses ftrace.

--- a/bpf-memleak.md
+++ b/bpf-memleak.md
@@ -9,7 +9,7 @@ In this lab, you will experiment with a C++ application that leaks memory over t
 First, build the [wordcount](wordcount.cc) application using the following command:
 
 ```
-$ c++ -fno-omit-frame-pointer -std=c++11 -g wordcount.cc -o wordcount
+$ g++ -fno-omit-frame-pointer -std=c++11 -g wordcount.cc -o wordcount
 ```
 
 Run the application. It prompts you for a file name and will display a word count if you provide a valid file name. For example, try the application source file, wordcount.cc. But that's not very interesting. Download one or two books from [Project Gutenberg](http://www.gutenberg.org) -- we like Jane Austen's "Pride and Prejudice", but that's totally up to you. Try giving these as input to the application.

--- a/bpf-opens.md
+++ b/bpf-opens.md
@@ -66,9 +66,9 @@ The `argdist` tool from BCC can be used for quick argument analysis when you're 
 # argdist -p $(pidof server) -H 'p::SyS_nanosleep(struct timespec *time):u64:time->tv_nsec'
 ```
 
-This prints a histogram of the sleep durations, which seem to be concentrated in one specific bin: 512-1023 ns. Indeed, inspecting the application source code you can verify that it calls `usleep(1)`, which corresponds to 1000 nanoseconds.
+This prints a histogram (using -H) of the sleep durations, which seem to be concentrated in one specific bin: 512-1023 ns. Indeed, inspecting the application source code you can verify that it calls `usleep(1)`, which corresponds to 1000 nanoseconds.
 
-Similarly, we could use `argdist` to get a frequency count of which files the application is trying to open:
+Similarly, we could use `argdist` to get a frequency count (using -C) of which files the application is trying to open:
 
 ```
 # argdist -p $(pidof server) -C 'p:c:open(char *filename):char*:filename'

--- a/bpf-opens.md
+++ b/bpf-opens.md
@@ -30,7 +30,7 @@ It looks like the process is spending a bit of time in kernel mode.
 
 #### Task 3: Snoop Syscalls
 
-If the process is running frequently in kernel mode, it must be making quite a bunch of syscalls. At the time of writing, BCC does not have a dedicated tool for snooping syscall statistics (but that would definitely make [a nice pull request!](https://github.com/iovisor/bcc)), so we're going to use `perf`:
+If the process is running frequently in kernel mode, it must be making quite a bunch of syscalls. [BCC] now has the [ucalls](https://github.com/iovisor/bcc/blob/master/tools/ucalls_example.txt) tool which can trace syscalls (and more), but we're going to stick with `perf` for now (you're encouraged to repeat this exercise using `ucalls`):
 
 ```
 # perf record -p $(pidof server) -e 'syscalls:sys_enter_*'

--- a/perf.md
+++ b/perf.md
@@ -30,10 +30,12 @@ It's time to find out what's taking so long to count our primes. Use the followi
 
 ```
 # export OMP_NUM_THREADS=16
-# perf record -ag -F 997 -- ./primes
+# perf record -g -F 997 -- ./primes
 ```
 
-> In the preceding command, the -a switch indicates that you want to capture samples on all CPUs; the -g switch indicates that you want the call stack to be captured; the -F switch indicates that your event of interest is CPU samples; and the number 997 is the rate of sampling -- 997 times per second.
+> In the preceding command, the -g switch indicates that you want the call stack to be captured; the -F switch lets you set the rate of sampling for events -- 997 times times per second in this case.
+> The trace will include events aggregated across all threads spawned by `primes`. To include events from other system-wide processes while the program is running, specify `-a`, and if you really want
+> to trace only a single thread within a process group, you can use use `-t`.
 
 To figure out where the bottleneck is, inspect `perf`'s report:
 


### PR DESCRIPTION
This is a wonderful resource and I'm excited to pick up these new tools. 
Here are a bunch of fixes and tweaks from reading through it all, pick what you like, force-push changes, etc'.

One slightly subtle point, I went ahead and verified that `-a` in `perf-record` has nothing to do with tracing
multi-threaded programs, it's solely about tracing system-wide events in addition to events within the process group. I have a test program if you're interested, or just trust me...