### PR TITLE
update postgres INSERT to use single quotes

### DIFF
--- a/bpf-oneliners.md
+++ b/bpf-oneliners.md
@@ -68,7 +68,7 @@ Now, go back to the psql shell and run some SQL statements. For example:
 
 ```
 create table info (id integer primary key, name varchar(200));
-insert into info values (1, "Chair");
+insert into info values (1, 'Chair');
 select * from info;
 ```
 


### PR DESCRIPTION
Ran across this error when doing the bpf-oneliners exercise

```
postgres=#insert into info values (1, "Chair");
postgres=# ERROR:  column "Chair" does not exist
LINE 1: insert into info values (1, "Chair");
```