### PR TITLE
Use -c option in syscount to show counts by syscall name

### DIFF
--- a/bpf-opens.md
+++ b/bpf-opens.md
@@ -33,7 +33,7 @@ It looks like the process is spending a bit of time in kernel mode.
 If the process is running frequently in kernel mode, it must be making quite a bunch of syscalls. To characterize its workload, we can use the BCC `syscount` tool:
 
 ```
-# syscount -p $(pidof server)
+# syscount -c -p $(pidof server)
 ```
 
 This collects all syscall events. Press Ctrl+C after a few seconds to stop collection. It looks like the application is calling `nanosleep()` and `open()` quite frequently.


### PR DESCRIPTION
According to the [`syscount` docs](https://github.com/brendangregg/perf-tools/blob/master/syscount#L75), the `-c` option show counts by syscall name.

We need that to see that the application is calling  `nanosleep()` and `open()` quite frequently, as the description says.